### PR TITLE
Handle error that occurred

### DIFF
--- a/app/Http/Controllers/StoreController.php
+++ b/app/Http/Controllers/StoreController.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Store;
+use App\Models\Tenant;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class StoreController extends Controller
+{
+    /**
+     * Display a listing of the stores.
+     */
+    public function index()
+    {
+        $user = auth()->user();
+        
+        // Check if user can manage all tenants (Super Admin)
+        if ($user->hasPermissionTo('tenants.manage.all')) {
+            $stores = Store::with('tenant')->latest()->paginate(10);
+        } else {
+            // Tenant owner can only see their own stores
+            $stores = Store::where('tenant_id', $user->tenant_id)
+                           ->with('tenant')
+                           ->latest()
+                           ->paginate(10);
+        }
+
+        return Inertia::render('Stores/Index', [
+            'stores' => $stores,
+            'canManageAll' => $user->hasPermissionTo('tenants.manage.all'),
+        ]);
+    }
+
+    /**
+     * Show the form for creating a new store.
+     */
+    public function create()
+    {
+        $user = auth()->user();
+        
+        // Only Super Admins can create stores
+        if (!$user->hasPermissionTo('tenants.manage.all')) {
+            abort(403, 'Unauthorized to create stores');
+        }
+
+        $tenants = Tenant::all();
+
+        return Inertia::render('Stores/Create', [
+            'tenants' => $tenants,
+        ]);
+    }
+
+    /**
+     * Store a newly created store in storage.
+     */
+    public function store(Request $request)
+    {
+        $user = auth()->user();
+        
+        // Only Super Admins can create stores
+        if (!$user->hasPermissionTo('tenants.manage.all')) {
+            abort(403, 'Unauthorized to create stores');
+        }
+
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'address' => 'required|string|max:500',
+            'phone' => 'nullable|string|max:20',
+            'email' => 'nullable|email|max:255',
+            'tenant_id' => 'required|exists:tenants,id',
+            'status' => 'required|in:active,inactive',
+        ]);
+
+        $store = Store::create($validated);
+
+        return redirect()->route('stores.index')
+                        ->with('success', 'Store created successfully.');
+    }
+
+    /**
+     * Display the specified store.
+     */
+    public function show(Store $store)
+    {
+        $user = auth()->user();
+        
+        // Check permissions
+        if (!$user->hasPermissionTo('tenants.manage.all') && $store->tenant_id !== $user->tenant_id) {
+            abort(403, 'Unauthorized to view this store');
+        }
+
+        $store->load('tenant');
+
+        return Inertia::render('Stores/Show', [
+            'store' => $store,
+            'canManageAll' => $user->hasPermissionTo('tenants.manage.all'),
+        ]);
+    }
+
+    /**
+     * Show the form for editing the specified store.
+     */
+    public function edit(Store $store)
+    {
+        $user = auth()->user();
+        
+        // Check permissions
+        if (!$user->hasPermissionTo('tenants.manage.all') && $store->tenant_id !== $user->tenant_id) {
+            abort(403, 'Unauthorized to edit this store');
+        }
+
+        $tenants = $user->hasPermissionTo('tenants.manage.all') ? Tenant::all() : collect();
+
+        return Inertia::render('Stores/Edit', [
+            'store' => $store,
+            'tenants' => $tenants,
+            'canManageAll' => $user->hasPermissionTo('tenants.manage.all'),
+        ]);
+    }
+
+    /**
+     * Update the specified store in storage.
+     */
+    public function update(Request $request, Store $store)
+    {
+        $user = auth()->user();
+        
+        // Check permissions
+        if (!$user->hasPermissionTo('tenants.manage.all') && $store->tenant_id !== $user->tenant_id) {
+            abort(403, 'Unauthorized to update this store');
+        }
+
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'address' => 'required|string|max:500',
+            'phone' => 'nullable|string|max:20',
+            'email' => 'nullable|email|max:255',
+            'tenant_id' => $user->hasPermissionTo('tenants.manage.all') ? 'required|exists:tenants,id' : 'prohibited',
+            'status' => 'required|in:active,inactive',
+        ]);
+
+        // If not Super Admin, preserve the original tenant_id
+        if (!$user->hasPermissionTo('tenants.manage.all')) {
+            $validated['tenant_id'] = $store->tenant_id;
+        }
+
+        $store->update($validated);
+
+        return redirect()->route('stores.index')
+                        ->with('success', 'Store updated successfully.');
+    }
+
+    /**
+     * Remove the specified store from storage.
+     */
+    public function destroy(Store $store)
+    {
+        $user = auth()->user();
+        
+        // Check permissions
+        if (!$user->hasPermissionTo('tenants.manage.all') && $store->tenant_id !== $user->tenant_id) {
+            abort(403, 'Unauthorized to delete this store');
+        }
+
+        $store->delete();
+
+        return redirect()->route('stores.index')
+                        ->with('success', 'Store deleted successfully.');
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,143 @@
+<?php
+
+use App\Http\Controllers\ProfileController;
+use App\Models\Tenant;
+use Illuminate\Foundation\Application;
+use Illuminate\Support\Facades\Route;
+use Inertia\Inertia;
+
+/*
+|--------------------------------------------------------------------------
+| Web Routes
+|--------------------------------------------------------------------------
+|
+| Here is where you can register web routes for your application. These
+| routes are loaded by the RouteServiceProvider within a group which
+| contains the "web" middleware group. Now create something great!
+|
+*/
+
+Route::get('/', function () {
+    return Inertia::render('Welcome', [
+        'canLogin' => Route::has('login'),
+        'canRegister' => Route::has('register'),
+        'laravelVersion' => Application::VERSION,
+        'phpVersion' => PHP_VERSION,
+    ]);
+});
+
+Route::middleware('auth')->group(function () {
+    Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
+    Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
+    Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+});
+
+// Test route for permission system
+Route::get('/test-permissions', function () {
+    if (auth()->check()) {
+        $user = auth()->user();
+        return response()->json([
+            'user_id' => $user->id,
+            'user_name' => $user->name,
+            'roles' => $user->getRoleNames(),
+            'permissions' => $user->getAllPermissions()->pluck('name'),
+        ]);
+    }
+    return response()->json(['message' => 'Not authenticated']);
+})->middleware('auth');
+
+// Business Management Routes - Super Admin only
+Route::middleware(['auth', 'permission:tenants.manage.all'])->group(function () {
+    // Tenants - Only Super Admin can manage all tenants
+    Route::resource('tenants', \App\Http\Controllers\TenantController::class);
+});
+
+// Tenant-specific routes - Tenant Owners can access their own tenant
+Route::middleware(['auth', 'permission:tenant.own.manage'])->group(function () {
+    // Tenant Dashboard - shows tenant-specific data
+    Route::get('/tenant-dashboard', [\App\Http\Controllers\TenantDashboardController::class, 'index'])
+        ->name('tenant.dashboard');
+    
+    // Tenant Owners can view their own tenant
+    Route::get('/my-tenant', function () {
+        $user = auth()->user();
+        $tenant = Tenant::findOrFail($user->tenant_id);
+        return Inertia::render('Tenants/Show', [
+            'tenant' => $tenant,
+            'canManageAll' => false
+        ]);
+    })->name('my.tenant');
+});
+
+// Store creation routes - only for Super Admins (must come first to avoid conflicts)
+Route::middleware(['auth', 'permission:tenants.manage.all'])->group(function () {
+    Route::get('/stores/create', [\App\Http\Controllers\StoreController::class, 'create'])->name('stores.create');
+    Route::post('/stores', [\App\Http\Controllers\StoreController::class, 'store'])->name('stores.store');
+});
+
+// Store management routes - restricted by tenant ownership
+Route::middleware(['auth', 'permission:tenant.own.stores.manage'])->group(function () {
+    Route::get('/stores', [\App\Http\Controllers\StoreController::class, 'index'])->name('stores.index');
+    Route::get('/stores/{store}', [\App\Http\Controllers\StoreController::class, 'show'])->name('stores.show');
+    Route::get('/stores/{store}/edit', [\App\Http\Controllers\StoreController::class, 'edit'])->name('stores.edit');
+    Route::patch('/stores/{store}', [\App\Http\Controllers\StoreController::class, 'update'])->name('stores.update');
+    Route::delete('/stores/{store}', [\App\Http\Controllers\StoreController::class, 'destroy'])->name('stores.destroy');
+});
+
+// Staff management - restricted by tenant ownership
+Route::middleware(['auth', 'permission:tenant.own.staff.manage'])->group(function () {
+    Route::resource('staff-profiles', \App\Http\Controllers\StaffProfileController::class);
+});
+
+// Customer management - restricted by tenant ownership
+Route::middleware(['auth', 'permission:tenant.own.customers.manage'])->group(function () {
+    Route::resource('customers', \App\Http\Controllers\CustomerController::class);
+});
+
+// Supplier management - restricted by tenant ownership
+Route::middleware(['auth', 'permission:tenant.own.suppliers.manage'])->group(function () {
+    Route::resource('suppliers', \App\Http\Controllers\SupplierController::class);
+});
+
+// Payroll management - restricted by tenant ownership
+Route::middleware(['auth', 'permission:tenant.own.payroll.manage', 'tenant.access:payroll'])->group(function () {
+    Route::resource('payrolls', \App\Http\Controllers\PayrollController::class);
+});
+
+// Test route for suppliers (temporarily without permission middleware)
+Route::get('/test-suppliers', function () {
+    return Inertia::render('Suppliers/Index', [
+        'suppliers' => \App\Models\Supplier::with('store')->latest()->paginate(10),
+        'stores' => \App\Models\Store::all()
+    ]);
+})->middleware(['auth'])->name('test.suppliers');
+
+// Dashboard with business overview - accessible after login
+Route::get('/dashboard', function () {
+    $user = auth()->user();
+    
+    // Get basic stats
+    $stats = [
+        'stores' => \App\Models\Store::count(),
+        'staff' => \App\Models\StaffProfile::count(),
+        'customers' => \App\Models\Customer::count(),
+        'suppliers' => \App\Models\Supplier::count(),
+    ];
+    
+    // Get recent data for dashboard
+    $recentTenants = \App\Models\Tenant::latest()->take(5)->get();
+    $recentStores = \App\Models\Store::with('tenant')->latest()->take(5)->get();
+    $recentStaff = \App\Models\StaffProfile::with('user')->latest()->take(5)->get();
+    
+    return Inertia::render('Dashboard', [
+        'user' => $user,
+        'stats' => $stats,
+        'recentTenants' => $recentTenants,
+        'recentStores' => $recentStores,
+        'recentStaff' => $recentStaff,
+        'recentActivities' => [], // Empty for now, can be populated later
+        'canManageAll' => $user->hasPermissionTo('tenants.manage.all'),
+    ]);
+})->middleware(['auth', 'verified'])->name('dashboard');
+
+require __DIR__.'/auth.php';


### PR DESCRIPTION
Create `StoreController` and refactor store routes to resolve SQL error caused by routing conflicts.

The error `SQLSTATE[22P02]: Invalid text representation: 7 ERROR: invalid input syntax for type bigint: "create"` occurred because Laravel was treating the "create" segment in `/stores/create` as an ID parameter for a `show` or `edit` route. This was due to the absence of a `StoreController` and the order of route definitions. The changes introduce the necessary controller and explicitly define `create` and `store` routes before more general resource-like routes to ensure correct routing precedence.

---
<a href="https://cursor.com/background-agent?bcId=bc-42064ebb-db5e-41c8-b1f4-959fae3d5e54">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-42064ebb-db5e-41c8-b1f4-959fae3d5e54">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

